### PR TITLE
Adding methods to AtlasContentGroupClient that takes api key

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,17 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jmock</groupId>
+            <artifactId>jmock-junit4</artifactId>
+            <version>2.5.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>1.9.0</version>

--- a/src/main/java/org/atlasapi/client/AtlasContentGroupClient.java
+++ b/src/main/java/org/atlasapi/client/AtlasContentGroupClient.java
@@ -5,11 +5,17 @@ import org.atlasapi.media.entity.simple.ContentQueryResult;
 
 import com.google.common.base.Optional;
 
-
 public interface AtlasContentGroupClient {
-    ContentGroupQueryResult contentGroup(String id);    
-    
-    ContentGroupQueryResult contentGroups();    
-    
+
+    ContentGroupQueryResult contentGroup(String id);
+
+    ContentGroupQueryResult contentGroup(String id, Optional<String> apiKey);
+
+    ContentGroupQueryResult contentGroups();
+
+    ContentGroupQueryResult contentGroups(Optional<String> apiKey);
+
     ContentQueryResult contentFor(String contentGroupid, Optional<ContentQuery> contentQuery);
+
+    ContentQueryResult contentFor(String contentGroupid, Optional<ContentQuery> contentQuery, Optional<String> apiKey);
 }

--- a/src/main/java/org/atlasapi/client/GsonContentGroupClient.java
+++ b/src/main/java/org/atlasapi/client/GsonContentGroupClient.java
@@ -22,32 +22,69 @@ public class GsonContentGroupClient implements AtlasContentGroupClient {
         this.contentGroupContentQueryPattern = String.format("http://%s/3.0/content_groups/%%s/content.json", atlasHost);
         this.client = new GsonQueryClient();
     }
+
+    public GsonContentGroupClient(HostSpecifier atlasHost, Optional<String> apiKey,
+            GsonQueryClient client) {
+        this.apiKey = apiKey;
+        this.singleContentGroupQueryPattern = String.format("http://%s/3.0/content_groups/%%s.json", atlasHost);
+        this.contentGroupsQuery = String.format("http://%s/3.0/content_groups.json", atlasHost);
+        this.contentGroupContentQueryPattern = String.format("http://%s/3.0/content_groups/%%s/content.json", atlasHost);
+        this.client = client;
+    }
     
     @Override
     public ContentGroupQueryResult contentGroup(String id) {
-        return client.contentGroupQuery(appendApiKey(String.format(singleContentGroupQueryPattern, id)));
+        return this.contentGroup(id, apiKey);
+    }
+
+    @Override
+    public ContentGroupQueryResult contentGroup(String id, Optional<String> apiKey) {
+        return client.contentGroupQuery(appendApiKey(
+                String.format(singleContentGroupQueryPattern, id),
+                apiKey
+        ));
     }
     
     @Override
     public ContentGroupQueryResult contentGroups() {
-        return client.contentGroupQuery(appendApiKey(contentGroupsQuery));
+        return this.contentGroups(apiKey);
+    }
+
+    @Override
+    public ContentGroupQueryResult contentGroups(Optional<String> apiKey) {
+        return client.contentGroupQuery(appendApiKey(
+                contentGroupsQuery,
+                apiKey
+        ));
     }
     
     @Override
-    public ContentQueryResult contentFor(String contentGroupid, Optional<ContentQuery> contentQuery) {
-        String queryString = appendApiKey(String.format(contentGroupContentQueryPattern, contentGroupid));
+    public ContentQueryResult contentFor(String contentGroupId, Optional<ContentQuery> contentQuery) {
+        return this.contentFor(contentGroupId, contentQuery, apiKey);
+    }
+
+    @Override
+    public ContentQueryResult contentFor(String contentGroupId, Optional<ContentQuery> contentQuery,
+            Optional<String> apiKey) {
+        String queryString = appendApiKey(
+                String.format(contentGroupContentQueryPattern, contentGroupId),
+                apiKey
+        );
+        return executeContentQuery(contentQuery, queryString);
+    }
+
+    private ContentQueryResult executeContentQuery(Optional<ContentQuery> contentQuery,
+            String queryString) {
         if (contentQuery.isPresent()) {
             queryString = Urls.appendParameters(queryString, contentQuery.get().toQueryStringParameters());
         }
         return client.contentQuery(queryString);
     }
-    
-    private String appendApiKey(String uri) {
+
+    private String appendApiKey(String uri, Optional<String> apiKey) {
         if (apiKey.isPresent()) {
             return Urls.appendParameters(uri, "apiKey", apiKey.get());
         }
         return uri;
     }
-   
-
 }

--- a/src/test/java/org/atlasapi/client/GsonContentGroupClientTest.java
+++ b/src/test/java/org/atlasapi/client/GsonContentGroupClientTest.java
@@ -1,0 +1,103 @@
+package org.atlasapi.client;
+
+import com.google.common.base.Optional;
+import com.google.common.net.HostSpecifier;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GsonContentGroupClientTest {
+
+    @Mock private GsonQueryClient client;
+
+    private String id;
+    private String contentGroupId;
+    private HostSpecifier host;
+    private Optional<String> defaultApiKey;
+    private Optional<String> passedApiKey;
+    private GsonContentGroupClient contentGroupClient;
+
+    @Before
+    public void setUp() throws Exception {
+        this.id = "7es7";
+        this.contentGroupId = "hafafa2";
+
+        this.host = HostSpecifier.fromValid("atlas.metabroadcast.com");
+        this.defaultApiKey = Optional.of("adu98asf91hurffh9afga9sf7as7fasfasf");
+        this.passedApiKey = Optional.of("oadihf9dsvh9ads93rn23ofvd0vaaasdwdasd");
+        this.contentGroupClient = new GsonContentGroupClient(host, defaultApiKey, client);
+    }
+
+    @Test
+    public void gettingContentGroupQueryResultById() {
+        ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+
+        contentGroupClient.contentGroup(id);
+
+        verify(client).contentGroupQuery(argumentCaptor.capture());
+        assertEquals(argumentCaptor.getValue(), "http://atlas.metabroadcast.com/3.0/content_groups/7es7.json?apiKey="
+                + defaultApiKey.get());
+    }
+
+    @Test
+    public void gettingContentGroupQueryResultByIdAndApiKey() {
+        ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+
+        contentGroupClient.contentGroup(id, passedApiKey);
+
+        verify(client).contentGroupQuery(argumentCaptor.capture());
+        assertEquals(argumentCaptor.getValue(), "http://atlas.metabroadcast.com/3.0/content_groups/7es7.json?apiKey="
+                + passedApiKey.get());
+    }
+
+    @Test
+    public void gettingContentGroups() {
+        ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+
+        contentGroupClient.contentGroups();
+
+        verify(client).contentGroupQuery(argumentCaptor.capture());
+        assertEquals(argumentCaptor.getValue(), "http://atlas.metabroadcast.com/3.0/content_groups.json?apiKey="
+                + defaultApiKey.get());
+    }
+
+    @Test
+    public void gettingContentGroupsForGivenApiKey() {
+        ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+
+        contentGroupClient.contentGroups(passedApiKey);
+
+        verify(client).contentGroupQuery(argumentCaptor.capture());
+        assertEquals(argumentCaptor.getValue(), "http://atlas.metabroadcast.com/3.0/content_groups.json?apiKey="
+                + passedApiKey.get());
+    }
+
+    @Test
+    public void gettingContentGroupForGivenContentGroupId() {
+        ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+
+        contentGroupClient.contentFor(contentGroupId, Optional.<ContentQuery>absent());
+
+        verify(client).contentQuery(argumentCaptor.capture());
+        assertEquals(argumentCaptor.getValue(), "http://atlas.metabroadcast.com/3.0/content_groups/hafafa2/content.json?apiKey="
+                + defaultApiKey.get());
+    }
+
+    @Test
+    public void gettingContentGroupForGivenContentGroupIdAndApiKey() {
+        ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+
+        contentGroupClient.contentFor(contentGroupId, Optional.<ContentQuery>absent(), passedApiKey);
+
+        verify(client).contentQuery(argumentCaptor.capture());
+        assertEquals(argumentCaptor.getValue(), "http://atlas.metabroadcast.com/3.0/content_groups/hafafa2/content.json?apiKey="
+                + passedApiKey.get());
+    }
+}


### PR DESCRIPTION
Adding methods to AtlasContentGroupClient that takes api key as a mehod's parameter, so that it's possible to create a single GsonContentGroupClient and use different API keys for retrieving the content.