### PR TITLE
Updating GsonContentGroupClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,11 +56,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jmock</groupId>
-            <artifactId>jmock-junit4</artifactId>
-            <version>2.5.1</version>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>1.9.0</version>

--- a/src/main/java/org/atlasapi/client/GsonContentGroupClient.java
+++ b/src/main/java/org/atlasapi/client/GsonContentGroupClient.java
@@ -15,14 +15,6 @@ public class GsonContentGroupClient implements AtlasContentGroupClient {
     private final String contentGroupContentQueryPattern;
     private final GsonQueryClient client;
 
-    public GsonContentGroupClient(HostSpecifier atlasHost, Optional<String> apiKey) {
-        this.apiKey = apiKey;
-        this.singleContentGroupQueryPattern = String.format("http://%s/3.0/content_groups/%%s.json", atlasHost);
-        this.contentGroupsQuery = String.format("http://%s/3.0/content_groups.json", atlasHost);
-        this.contentGroupContentQueryPattern = String.format("http://%s/3.0/content_groups/%%s/content.json", atlasHost);
-        this.client = new GsonQueryClient();
-    }
-
     public GsonContentGroupClient(HostSpecifier atlasHost, Optional<String> apiKey,
             GsonQueryClient client) {
         this.apiKey = apiKey;
@@ -30,6 +22,10 @@ public class GsonContentGroupClient implements AtlasContentGroupClient {
         this.contentGroupsQuery = String.format("http://%s/3.0/content_groups.json", atlasHost);
         this.contentGroupContentQueryPattern = String.format("http://%s/3.0/content_groups/%%s/content.json", atlasHost);
         this.client = client;
+    }
+
+    public GsonContentGroupClient(HostSpecifier atlasHost, Optional<String> apiKey) {
+        this(atlasHost, apiKey, new GsonQueryClient());
     }
     
     @Override


### PR DESCRIPTION
Updating GsonContentGroupClient to reuse the constructor method to avoid code duplication.