### PR TITLE
Eng 988

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.atlasapi</groupId>
     <artifactId>atlas-client</artifactId>
-    <version>5.1-SNAPSHOT</version>
+    <version>5.7-SNAPSHOT</version>
     <description>Java Client for Atlas API</description>
     <build>
         <finalName>atlas-client</finalName>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.atlasapi</groupId>
     <artifactId>atlas-client</artifactId>
-    <version>5.7-SNAPSHOT</version>
+    <version>5.1-SNAPSHOT</version>
     <description>Java Client for Atlas API</description>
     <build>
         <finalName>atlas-client</finalName>

--- a/src/main/java/org/atlasapi/client/query/BroadcastAssertions.java
+++ b/src/main/java/org/atlasapi/client/query/BroadcastAssertions.java
@@ -54,7 +54,7 @@ public class BroadcastAssertions {
             this.from = checkNotNull(from);
             this.to = checkNotNull(to);
 
-            checkArgument(this.from.isBefore(this.to) || this.from.isEqual(this.to));
+            checkArgument(!this.from.isAfter(this.to));
         }
 
         public static BroadcastAssertion create(

--- a/src/main/java/org/atlasapi/client/query/BroadcastAssertions.java
+++ b/src/main/java/org/atlasapi/client/query/BroadcastAssertions.java
@@ -54,7 +54,7 @@ public class BroadcastAssertions {
             this.from = checkNotNull(from);
             this.to = checkNotNull(to);
 
-            checkArgument(this.from.isBefore(this.to));
+            checkArgument(this.from.isBefore(this.to) || this.from.isEqual(this.to));
         }
 
         public static BroadcastAssertion create(


### PR DESCRIPTION
Allows ingest thru owl client/API of zero duration broadcasts.
This relates to new PA API data, which is just like old PA
except ingested thru client, and the BroadcastAssertions
prevented broadcasts where startTime == endTime (for
no particular reason; the inner overlap checks are safe
for this kind of cases)